### PR TITLE
Fix install error for `fatal error: google/dense_hash_map`

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ pip install ninja
 ```sh
 pip install -r requirements.txt
 pip install inplace_abn
+apt-get install libsparsehash-dev
 FORCE_CUDA=1 pip install --no-cache-dir git+https://github.com/mit-han-lab/torchsparse.git@v1.4.0
 ```
 


### PR DESCRIPTION
### Need `libsparsehash-dev` before install `torchsparse` to sovle the issue below.

```log
      FAILED: /tmp/pip-req-build-oga6uqe0/build/temp.linux-x86_64-cpython-38/torchsparse/backend/hashmap/hashmap_cpu.o
      c++ -MMD -MF /tmp/pip-req-build-oga6uqe0/build/temp.linux-x86_64-cpython-38/torchsparse/backend/hashmap/hashmap_cpu.o.d -pthread -B /opt/conda/envs/geodream/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I/opt/conda/envs/geodream/lib/python3.8/site-packages/torch/include -I/opt/conda/envs/geodream/lib/python3.8/site-packages/torch/include/torch/csrc/api/include -I/opt/conda/envs/geodream/lib/python3.8/site-packages/torch/include/TH -I/opt/conda/envs/geodream/lib/python3.8/site-packages/torch/include/THC -I/usr/local/cuda/include -I/opt/conda/envs/geodream/include/python3.8 -c -c /tmp/pip-req-build-oga6uqe0/torchsparse/backend/hashmap/hashmap_cpu.cpp -o /tmp/pip-req-build-oga6uqe0/build/temp.linux-x86_64-cpython-38/torchsparse/backend/hashmap/hashmap_cpu.o -g -O3 -fopenmp -lgomp -DTORCH_API_INCLUDE_EXTENSION_H '-DPYBIND11_COMPILER_TYPE="_gcc"' '-DPYBIND11_STDLIB="_libstdcpp"' '-DPYBIND11_BUILD_ABI="_cxxabi1011"' -DTORCH_EXTENSION_NAME=backend -D_GLIBCXX_USE_CXX11_ABI=0 -std=c++14
      cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++
      In file included from /tmp/pip-req-build-oga6uqe0/torchsparse/backend/hashmap/hashmap_cpu.cpp:1:
      /tmp/pip-req-build-oga6uqe0/torchsparse/backend/hashmap/hashmap_cpu.hpp:8:10: fatal error: google/dense_hash_map: No such file or directory
       #include <google/dense_hash_map>
```

### Reference

https://github.com/facebookresearch/SparseConvNet/issues/96#issuecomment-487055082